### PR TITLE
Use nodes' app names for instruction logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+2022-12-13 (0.13.0)
+-------------------
+- Use nodes' app names for instruction logging.
+
 2022-11-15 (0.12.2)
 -------------------
 - Update SquidASM to 0.10.0.

--- a/netqasm/runtime/cli.py
+++ b/netqasm/runtime/cli.py
@@ -19,6 +19,7 @@ from netqasm.runtime.application import (
     post_function_from_path,
 )
 from netqasm.runtime.env import get_example_apps, init_folder, new_folder
+from netqasm.runtime.process_logs import _create_app_instr_logs
 from netqasm.runtime.settings import (
     Formalism,
     Simulator,
@@ -352,6 +353,8 @@ def simulate(
         enable_logging=log_to_files,
         hardware=hardware,
     )
+    _create_app_instr_logs(log_cfg.log_subroutines_dir)
+
     if timer:
         print(f"finished simulation in {round(time.perf_counter() - start, 2)} seconds")
 


### PR DESCRIPTION
We revert to the logging behaviour seen in v0.5.5, where output logs for specific nodes' instructions should use the app name in the filename.

Example, for an app (role) named 'receiver' located in 'delft':
`< v0.5.5` -> `receiver_instrs.yaml`
`v0.6.0 - v0.12.2` -> `delft_instrs.yaml`
`v0.13.0` (this PR) -> `receiver_instrs.yaml`


It was (likely) inadvertently changed to the node's location, rather than the app name, in v0.6.0. This mirrors the naming format of the `{app_name}_class_comm.yaml` files in the same logging directory.

This solution does what the old code used to do - simply re-write the files at the end of the simulation. 

I have an alternative solution that more deeply solves the issue, where the `Executor` class is aware of `app_name`s and uses them when creating `InstrLogger` instances. This touches both SquidASM and NetQASM, and involves changing the function signature in a few different places (though default values would make it the same in practice). Let me know if you'd prefer this alternative instead of this PR. 