### PR TITLE
Use nodes' app names for instruction logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+2022-12-13 (0.13.0)
+-------------------
+- Use nodes' app names for instruction logging.
+
 2022-11-15 (0.12.2)
 -------------------
 - Update SquidASM to 0.10.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 CHANGELOG
 =========
 
-2022-12-13 (0.13.0)
--------------------
-- Use nodes' app names for instruction logging.
-
 2022-11-15 (0.12.2)
 -------------------
 - Update SquidASM to 0.10.0.

--- a/netqasm/runtime/cli.py
+++ b/netqasm/runtime/cli.py
@@ -19,7 +19,7 @@ from netqasm.runtime.application import (
     post_function_from_path,
 )
 from netqasm.runtime.env import get_example_apps, init_folder, new_folder
-from netqasm.runtime.process_logs import _create_app_instr_logs
+from netqasm.runtime.process_logs import create_app_instr_logs
 from netqasm.runtime.settings import (
     Formalism,
     Simulator,
@@ -353,7 +353,7 @@ def simulate(
         enable_logging=log_to_files,
         hardware=hardware,
     )
-    _create_app_instr_logs(log_cfg.log_subroutines_dir)
+    create_app_instr_logs(log_cfg.log_subroutines_dir)
 
     if timer:
         print(f"finished simulation in {round(time.perf_counter() - start, 2)} seconds")

--- a/netqasm/runtime/cli.py
+++ b/netqasm/runtime/cli.py
@@ -19,6 +19,7 @@ from netqasm.runtime.application import (
     post_function_from_path,
 )
 from netqasm.runtime.env import get_example_apps, init_folder, new_folder
+from netqasm.runtime.process_logs import _create_app_instr_logs
 from netqasm.runtime.settings import (
     Formalism,
     Simulator,
@@ -352,6 +353,8 @@ def simulate(
         enable_logging=log_to_files,
         hardware=hardware,
     )
+    _create_app_instr_logs(log_cfg.log_subroutines_dir)
+
     if timer:
         print(f"finished simulation in {round(time.perf_counter() - start, 2)} seconds")
 

--- a/netqasm/runtime/process_logs.py
+++ b/netqasm/runtime/process_logs.py
@@ -11,7 +11,7 @@ _LAST_LOG = "LAST"
 def process_log(log_dir):
     # Add host line numbers to logs
     _add_hln_to_logs(log_dir)
-    _create_app_instr_logs(log_dir)
+    create_app_instr_logs(log_dir)
     make_last_log(log_dir)
 
 
@@ -65,7 +65,7 @@ def _add_hln_to_log_entry(subroutines, entry):
     entry["HFL"] = hostline.filename
 
 
-def _create_app_instr_logs(log_dir):
+def create_app_instr_logs(log_dir):
     file_end = "_instrs.yaml"
 
     app_names = BaseNetQASMConnection.get_app_names()

--- a/netqasm/sdk/connection.py
+++ b/netqasm/sdk/connection.py
@@ -85,7 +85,7 @@ class BaseNetQASMConnection(abc.ABC):
 
     # Global dict to track app names per node.
     # Currently only used for logging purposes, specifically only in
-    # `netqasm.runtime.process_logs._create_app_instr_logs`.
+    # `netqasm.runtime.process_logs.create_app_instr_logs`.
     # Dict[node_name, Dict[app_id, app_name]]
     _app_names: Dict[str, Dict[int, str]] = {}
 


### PR DESCRIPTION
We revert to the logging behaviour seen in v0.5.5, where output logs for specific nodes' instructions should use the app name in the filename.

Example, for an app (role) named 'receiver' located in 'delft':
`< v0.5.5` -> `receiver_instrs.yaml`
`v0.6.0 - v0.12.2` -> `delft_instrs.yaml`
`v0.13.0` (this PR) -> `receiver_instrs.yaml`


It was (likely) inadvertently changed to the node's location, rather than the app name, in v0.6.0. This mirrors the naming format of the `{app_name}_class_comm.yaml` files in the same logging directory.

This solution does what the old code used to do - simply re-write the files at the end of the simulation. 