### PR TITLE
Fix LAST instrs logs

### DIFF
--- a/netqasm/runtime/cli.py
+++ b/netqasm/runtime/cli.py
@@ -22,7 +22,7 @@ from netqasm.runtime.application import (
     post_function_from_path,
 )
 from netqasm.runtime.env import get_example_apps, init_folder, new_folder
-from netqasm.runtime.process_logs import create_app_instr_logs
+from netqasm.runtime.process_logs import create_app_instr_logs, make_last_log
 from netqasm.runtime.settings import (
     Formalism,
     Simulator,
@@ -357,6 +357,7 @@ def simulate(
         hardware=hardware,
     )
     create_app_instr_logs(log_cfg.log_subroutines_dir)
+    make_last_log(log_cfg.log_subroutines_dir)
 
     if timer:
         print(f"finished simulation in {round(time.perf_counter() - start, 2)} seconds")

--- a/netqasm/runtime/cli.py
+++ b/netqasm/runtime/cli.py
@@ -356,8 +356,9 @@ def simulate(
         enable_logging=log_to_files,
         hardware=hardware,
     )
-    create_app_instr_logs(log_cfg.log_subroutines_dir)
-    make_last_log(log_cfg.log_subroutines_dir)
+    if log_to_files:
+        create_app_instr_logs(log_cfg.log_subroutines_dir)
+        make_last_log(log_cfg.log_subroutines_dir)
 
     if timer:
         print(f"finished simulation in {round(time.perf_counter() - start, 2)} seconds")


### PR DESCRIPTION
Closes issue https://github.com/QuTech-Delft/netqasm/issues/55

While debugging I found that the names of the last logs were not correct because the renaming of the logs and the copying to the LAST directory happened in two separate places (the first in NetQASM and the second one in SquidASM). Due to this they were executed in the wrong order and the logs were copied to LAST before they were renamed.

I moved these calls to NetQASM and also made a PR for SquidASM to remove the calls there (see PR: https://github.com/QuTech-Delft/squidasm/pull/29). I chose to move them all to NetQASM instead of moving them all to SquidASM because it seems to me that this introduces the least breaking changes between different versions. With this method if you are running an older version of SquidASM then everything should still work fine since NetQASM will just overwrite the erroneous log files created by SquidASM.

If there are other reasons to prefer moving them to SquidASM instead I am also open for that as well but then we do need to keep in mind that this new version of SquidASM will no longer work with older versions of NetQASM and vice versa.