### PR TITLE
Fix PYSEC-2023-102 vulnerability

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ install_requires =
     click >=8.0, <9.0
     qlink-interface >=1.0, <2.0
     numpy >=1.22
-    scipy >=1.8
+    scipy >=1.11.1
     pyyaml >=6.0, <7.0
 
 [options.extras_require]
@@ -32,3 +32,4 @@ squidasm =
 [options.entry_points]
 console_scripts = 
     netqasm = netqasm.runtime.cli:cli
+


### PR DESCRIPTION
The SciPy dependency allows for installation of PYSEC-2023-102 vulnerability. This is fixed after 1.11.1.

- https://nvd.nist.gov/vuln/detail/CVE-2023-25399
- https://vulners.com/osv/OSV:PYSEC-2023-102