### PR TITLE
Fix connection getting flushed during exception handling

### DIFF
--- a/netqasm/sdk/connection.py
+++ b/netqasm/sdk/connection.py
@@ -308,7 +308,7 @@ class BaseNetQASMConnection(abc.ABC):
         self.close(
             clear_app=self._clear_app_on_exit,
             stop_backend=self._stop_backend_on_exit,
-            exception=exc_type is not None
+            exception=exc_type is not None,
         )
 
     def _get_new_app_id(self, app_id: Optional[int]) -> int:
@@ -343,7 +343,12 @@ class BaseNetQASMConnection(abc.ABC):
     def clear(self) -> None:
         self._pop_app_id()
 
-    def close(self, clear_app: bool = True, stop_backend: bool = False, exception: bool = False) -> None:
+    def close(
+        self,
+        clear_app: bool = True,
+        stop_backend: bool = False,
+        exception: bool = False,
+    ) -> None:
         """Close a connection.
 
         By default, this method is automatically called when a connection context ends.

--- a/netqasm/sdk/connection.py
+++ b/netqasm/sdk/connection.py
@@ -308,6 +308,7 @@ class BaseNetQASMConnection(abc.ABC):
         self.close(
             clear_app=self._clear_app_on_exit,
             stop_backend=self._stop_backend_on_exit,
+            exception=exc_type is not None
         )
 
     def _get_new_app_id(self, app_id: Optional[int]) -> int:
@@ -342,13 +343,14 @@ class BaseNetQASMConnection(abc.ABC):
     def clear(self) -> None:
         self._pop_app_id()
 
-    def close(self, clear_app: bool = True, stop_backend: bool = False) -> None:
+    def close(self, clear_app: bool = True, stop_backend: bool = False, exception: bool = False) -> None:
         """Close a connection.
 
         By default, this method is automatically called when a connection context ends.
         """
-        # Flush all pending commands
-        self.flush()
+        if not exception:
+            # Flush all pending commands
+            self.flush()
 
         self._pop_app_id()
 


### PR DESCRIPTION
Currently, when a connection's `__exit__` method is called due to an exception, the connection first flushes all its pending instructions in a blocking manner.
In practice, this means that exceptions are delayed until whatever is on the other end of the exception has completed its subroutine and returns the results.
Depending on whatever is on the other end of the connection, this could take up to an infinite amount of time.

This PR fixes this behaviour by adding a flag to the `close` method that makes it skip flushing during exception handling.