### PR TITLE
Add REIDS language support

### DIFF
--- a/netqasm/lang/instr/flavour.py
+++ b/netqasm/lang/instr/flavour.py
@@ -112,3 +112,12 @@ class NVFlavour(Flavour):
 
     def __init__(self):
         super().__init__(self.instrs)
+
+
+class REIDSFlavour(Flavour):
+    @property
+    def instrs(self):
+        return []
+
+    def __init__(self):
+        super().__init__(self.instrs)


### PR DESCRIPTION
This PR adds support for the REIDS hardware platform to NetQASM.

REIDS is a very simple platform that only supports the Core instruction set, and even then `MeasBasisInstruction` will require external help to perform the rotation.