### PR TITLE
Decompose Z gates in bell state corrections when compiling for hardware

### DIFF
--- a/netqasm/sdk/build_epr.py
+++ b/netqasm/sdk/build_epr.py
@@ -28,6 +28,7 @@ class EntRequestParams:
     time_unit: TimeUnit = TimeUnit.MICRO_SECONDS
     max_time: int = 0
     expect_phi_plus: bool = True
+    expect_psi_plus: bool = False
     min_fidelity_all_at_end: Optional[int] = None
     max_tries: Optional[int] = None
     random_basis_local: Optional[RandomBasis] = None

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1371,7 +1371,11 @@ class Builder:
             ):  # Psi- -> apply X-gate and Z-gate
                 correction_cmds = [
                     ICmd(instruction=GenericInstr.ROT_X, operands=[qubit_reg, 16, 4]),
-                    ICmd(instruction=GenericInstr.ROT_Z, operands=[qubit_reg, 16, 4]),
+                    # ICmd(instruction=GenericInstr.ROT_Z, operands=[qubit_reg, 16, 4]),
+                    # Decompose Z180 into Y90, X180, -Y90
+                    ICmd(instruction=GenericInstr.ROT_Y, operands=[qubit_reg, 8, 4]),
+                    ICmd(instruction=GenericInstr.ROT_X, operands=[qubit_reg, 16, 4]),
+                    ICmd(instruction=GenericInstr.ROT_Y, operands=[qubit_reg, 24, 4]),
                 ]
                 self.subrt_add_pending_commands(correction_cmds)  # type: ignore
         else:

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1526,8 +1526,7 @@ class Builder:
 
         self.subrt_add_pending_commands(wait_cmds)  # type: ignore
 
-        # if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
-        if params.expect_phi_plus or params.expect_psi_plus:
+        if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
             self._build_cmds_epr_keep_corrections(
                 qubit_ids_array, ent_results_array, params
             )
@@ -1667,8 +1666,7 @@ class Builder:
 
         self.subrt_add_pending_commands(wait_cmds)  # type: ignore
 
-        # if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
-        if params.expect_phi_plus or params.expect_psi_plus:
+        if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
             self._build_cmds_epr_keep_corrections(
                 qubit_ids_array, ent_results_array, params
             )

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1522,7 +1522,8 @@ class Builder:
 
         self.subrt_add_pending_commands(wait_cmds)  # type: ignore
 
-        if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
+        # if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
+        if params.expect_phi_plus or params.expect_psi_plus:
             self._build_cmds_epr_keep_corrections(
                 qubit_ids_array, ent_results_array, params
             )
@@ -1662,7 +1663,8 @@ class Builder:
 
         self.subrt_add_pending_commands(wait_cmds)  # type: ignore
 
-        if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
+        # if wait_all and (params.expect_phi_plus or params.expect_psi_plus):
+        if params.expect_phi_plus or params.expect_psi_plus:
             self._build_cmds_epr_keep_corrections(
                 qubit_ids_array, ent_results_array, params
             )
@@ -1891,6 +1893,8 @@ class Builder:
             wait_all = False
         else:
             wait_all = True
+       
+        self._connection._logger.info(f"wait_all = {wait_all}")
 
         if reset_results_array:
             self._build_cmds_undefine_array(ent_results_array)

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -373,7 +373,9 @@ class Builder:
                 pair=pair,
             )
 
-            if (params.expect_phi_plus or params.expect_psi_plus) and role == EPRRole.RECV:
+            if (
+                params.expect_phi_plus or params.expect_psi_plus
+            ) and role == EPRRole.RECV:
                 # Perform Bell corrections
                 bell_state = self._get_raw_bell_state(
                     ent_results_array, loop_reg, bell_state_reg
@@ -382,7 +384,9 @@ class Builder:
                     instruction=GenericInstr.SET, operands=[qubit_reg, 0]
                 )
                 self.subrt_add_pending_command(set_qubit_reg_cmd)  # type: ignore
-                self._build_cmds_epr_keep_corrections_single_pair(bell_state, qubit_reg, params)
+                self._build_cmds_epr_keep_corrections_single_pair(
+                    bell_state, qubit_reg, params
+                )
 
             # If it's the last pair, don't move it to a mem qubit
             with loop_reg.if_ne(params.number - 1):
@@ -444,7 +448,9 @@ class Builder:
             )
             assert tp == EPRType.K or tp == EPRType.R
 
-            if (params.expect_phi_plus or params.expect_psi_plus) and role == EPRRole.RECV:
+            if (
+                params.expect_phi_plus or params.expect_psi_plus
+            ) and role == EPRRole.RECV:
                 bell_state = self._get_raw_bell_state(
                     ent_results_array, loop_reg, bell_state_reg
                 )
@@ -452,7 +458,9 @@ class Builder:
                     instruction=GenericInstr.SET, operands=[qubit_reg, 0]
                 )
                 self.subrt_add_pending_command(set_qubit_reg_cmd)  # type: ignore
-                self._build_cmds_epr_keep_corrections_single_pair(bell_state, qubit_reg, params)
+                self._build_cmds_epr_keep_corrections_single_pair(
+                    bell_state, qubit_reg, params
+                )
 
             q_id = qubit_ids.get_future_index(loop_register)
             q = FutureQubit(conn=conn, future_id=q_id)
@@ -1353,7 +1361,10 @@ class Builder:
         )
 
     def _build_cmds_epr_keep_corrections_single_pair(
-        self, bell_state: RegFuture, qubit_reg: operand.Register, params: EntRequestParams
+        self,
+        bell_state: RegFuture,
+        qubit_reg: operand.Register,
+        params: EntRequestParams,
     ) -> None:
         if params.expect_phi_plus:
             with bell_state.if_eq(BellState.PHI_MINUS.value):  # Phi- -> apply Z-gate
@@ -1385,15 +1396,15 @@ class Builder:
                     ICmd(instruction=GenericInstr.ROT_X, operands=[qubit_reg, 16, 4])
                 ]
                 self.subrt_add_pending_commands(correction_cmds)  # type: ignore
-            with bell_state.if_eq(BellState.PHI_MINUS.value):  # Phi- -> apply X-gate and Z-gate
+            with bell_state.if_eq(
+                BellState.PHI_MINUS.value
+            ):  # Phi- -> apply X-gate and Z-gate
                 correction_cmds = [
                     ICmd(instruction=GenericInstr.ROT_X, operands=[qubit_reg, 16, 4]),
-                    ICmd(instruction=GenericInstr.ROT_Z, operands=[qubit_reg, 16, 4])
+                    ICmd(instruction=GenericInstr.ROT_Z, operands=[qubit_reg, 16, 4]),
                 ]
                 self.subrt_add_pending_commands(correction_cmds)  # type: ignore
-            with bell_state.if_eq(
-                BellState.PSI_MINUS.value
-            ):  # Psi- -> apply Z-gate
+            with bell_state.if_eq(BellState.PSI_MINUS.value):  # Psi- -> apply Z-gate
                 correction_cmds = [
                     ICmd(instruction=GenericInstr.ROT_Z, operands=[qubit_reg, 16, 4]),
                 ]
@@ -1419,7 +1430,9 @@ class Builder:
                 instruction=GenericInstr.SET, operands=[qubit_reg, 0]
             )
             self.subrt_add_pending_command(set_qubit_reg_cmd)  # type: ignore
-            self._build_cmds_epr_keep_corrections_single_pair(bell_state, qubit_reg, params)
+            self._build_cmds_epr_keep_corrections_single_pair(
+                bell_state, qubit_reg, params
+            )
 
         self._build_cmds_loop_body(
             loop, stop=params.number, loop_register=loop_register
@@ -1895,7 +1908,7 @@ class Builder:
             wait_all = False
         else:
             wait_all = True
-       
+
         self._connection._logger.info(f"wait_all = {wait_all}")
 
         if reset_results_array:

--- a/netqasm/sdk/epr_socket.py
+++ b/netqasm/sdk/epr_socket.py
@@ -644,6 +644,7 @@ class EPRSocket(abc.ABC):
         post_routine: Optional[Callable] = None,
         sequential: bool = False,
         expect_phi_plus: bool = True,
+        expect_psi_plus: bool = False,
         min_fidelity_all_at_end: Optional[int] = None,
         max_tries: Optional[int] = None,
     ) -> List[Qubit]:
@@ -680,6 +681,8 @@ class EPRSocket(abc.ABC):
 
         if self.conn is None:
             raise RuntimeError("EPRSocket does not have an open connection")
+        
+        assert not (expect_phi_plus and expect_psi_plus), "cannot ask for both phi+ and psi+"
 
         qubits, _ = self.conn._builder.sdk_recv_epr_keep(
             params=EntRequestParams(
@@ -689,6 +692,7 @@ class EPRSocket(abc.ABC):
                 post_routine=post_routine,
                 sequential=sequential,
                 expect_phi_plus=expect_phi_plus,
+                expect_psi_plus=expect_psi_plus,
                 min_fidelity_all_at_end=min_fidelity_all_at_end,
                 max_tries=max_tries,
             ),

--- a/netqasm/sdk/epr_socket.py
+++ b/netqasm/sdk/epr_socket.py
@@ -681,8 +681,10 @@ class EPRSocket(abc.ABC):
 
         if self.conn is None:
             raise RuntimeError("EPRSocket does not have an open connection")
-        
-        assert not (expect_phi_plus and expect_psi_plus), "cannot ask for both phi+ and psi+"
+
+        assert not (
+            expect_phi_plus and expect_psi_plus
+        ), "cannot ask for both phi+ and psi+"
 
         qubits, _ = self.conn._builder.sdk_recv_epr_keep(
             params=EntRequestParams(

--- a/netqasm/sdk/transpile.py
+++ b/netqasm/sdk/transpile.py
@@ -579,7 +579,7 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
                 ),
             ]
         elif isinstance(instr, vanilla.RotZInstruction):
-            if get_is_using_hardware():
+            if get_is_using_hardware() and instr.angle_denom.value != 4:
                 imm0, imm1 = get_hardware_num_denom(instr)
             else:
                 imm0, imm1 = instr.angle_num, instr.angle_denom
@@ -589,7 +589,7 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
                 ),
             ]
         elif isinstance(instr, vanilla.RotXInstruction):
-            if get_is_using_hardware():
+            if get_is_using_hardware() and instr.angle_denom.value != 4:
                 imm0, imm1 = get_hardware_num_denom(instr)
             else:
                 imm0, imm1 = instr.angle_num, instr.angle_denom
@@ -599,7 +599,7 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
                 ),
             ]
         elif isinstance(instr, vanilla.RotYInstruction):
-            if get_is_using_hardware():
+            if get_is_using_hardware() and instr.angle_denom.value != 4:
                 imm0, imm1 = get_hardware_num_denom(instr)
             else:
                 imm0, imm1 = instr.angle_num, instr.angle_denom

--- a/tests/test_sdk/test_connection.py
+++ b/tests/test_sdk/test_connection.py
@@ -253,7 +253,7 @@ set R6 10
 wait_all @0[R5:R6]
 set R2 0
 set R5 1
-beq R2 R5 44
+beq R2 R5 42
 load R0 @1[R2]
 set R3 9
 set R4 0
@@ -272,11 +272,9 @@ set R5 1
 bne R1 R5 35
 rot_x R0 16 4
 set R5 2
-bne R1 R5 41
+bne R1 R5 39
 rot_x R0 16 4
-rot_y R0 8 4
-rot_x R0 16 4
-rot_y R0 24 4
+rot_z R0 16 4
 set R5 1
 add R2 R2 R5
 jmp 16
@@ -284,6 +282,7 @@ set Q0 0
 h Q0
 ret_arr @0
 ret_arr @1
+ret_arr @2
 """
 
     expected = parse_text_subroutine(expected_text)
@@ -403,7 +402,7 @@ set R6 20
 wait_all @0[R5:R6]
 set R2 0
 set R5 2
-beq R2 R5 47
+beq R2 R5 45
 load R0 @1[R2]
 set R3 9
 set R4 0
@@ -422,11 +421,9 @@ set R5 1
 bne R1 R5 38
 rot_x R0 16 4
 set R5 2
-bne R1 R5 44
+bne R1 R5 42
 rot_x R0 16 4
-rot_y R0 8 4
-rot_x R0 16 4
-rot_y R0 24 4
+rot_z R0 16 4
 set R5 1
 add R2 R2 R5
 jmp 19
@@ -436,6 +433,7 @@ set Q0 1
 h Q0
 ret_arr @0
 ret_arr @1
+ret_arr @2
     """
 
     expected = parse_text_subroutine(expected_text)
@@ -721,7 +719,7 @@ set R6 10
 wait_all @0[R5:R6]
 set R2 0
 set R5 1
-beq R2 R5 44
+beq R2 R5 42
 load R0 @1[R2]
 set R3 9
 set R4 0
@@ -740,11 +738,9 @@ set R5 1
 bne R1 R5 35
 rot_x R0 16 4
 set R5 2
-bne R1 R5 41
+bne R1 R5 39
 rot_x R0 16 4
-rot_y R0 8 4
-rot_x R0 16 4
-rot_y R0 24 4
+rot_z R0 16 4
 set R5 1
 add R2 R2 R5
 jmp 16

--- a/tests/test_sdk/test_connection.py
+++ b/tests/test_sdk/test_connection.py
@@ -253,7 +253,7 @@ set R6 10
 wait_all @0[R5:R6]
 set R2 0
 set R5 1
-beq R2 R5 42
+beq R2 R5 44
 load R0 @1[R2]
 set R3 9
 set R4 0
@@ -272,9 +272,11 @@ set R5 1
 bne R1 R5 35
 rot_x R0 16 4
 set R5 2
-bne R1 R5 39
+bne R1 R5 41
 rot_x R0 16 4
-rot_z R0 16 4
+rot_y R0 8 4
+rot_x R0 16 4
+rot_y R0 24 4
 set R5 1
 add R2 R2 R5
 jmp 16
@@ -282,7 +284,6 @@ set Q0 0
 h Q0
 ret_arr @0
 ret_arr @1
-ret_arr @2
 """
 
     expected = parse_text_subroutine(expected_text)
@@ -402,7 +403,7 @@ set R6 20
 wait_all @0[R5:R6]
 set R2 0
 set R5 2
-beq R2 R5 45
+beq R2 R5 47
 load R0 @1[R2]
 set R3 9
 set R4 0
@@ -421,9 +422,11 @@ set R5 1
 bne R1 R5 38
 rot_x R0 16 4
 set R5 2
-bne R1 R5 42
+bne R1 R5 44
 rot_x R0 16 4
-rot_z R0 16 4
+rot_y R0 8 4
+rot_x R0 16 4
+rot_y R0 24 4
 set R5 1
 add R2 R2 R5
 jmp 19
@@ -433,7 +436,6 @@ set Q0 1
 h Q0
 ret_arr @0
 ret_arr @1
-ret_arr @2
     """
 
     expected = parse_text_subroutine(expected_text)
@@ -719,7 +721,7 @@ set R6 10
 wait_all @0[R5:R6]
 set R2 0
 set R5 1
-beq R2 R5 42
+beq R2 R5 44
 load R0 @1[R2]
 set R3 9
 set R4 0
@@ -738,9 +740,11 @@ set R5 1
 bne R1 R5 35
 rot_x R0 16 4
 set R5 2
-bne R1 R5 39
+bne R1 R5 41
 rot_x R0 16 4
-rot_z R0 16 4
+rot_y R0 8 4
+rot_x R0 16 4
+rot_y R0 24 4
 set R5 1
 add R2 R2 R5
 jmp 16


### PR DESCRIPTION
- Decompose Z gate into YXY in Bell state corrections when compiling for NV hardware
- Add optional `expect_psi_plus` parameter to entanglement request struct