### PR TITLE
Fix empty pickle file by adding missing optional log_config argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ htmlcov/
 .idea/*
 .vscode/*
 .venv*/
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov/
 .coverage
 .idea/*
 .vscode/*
+.venv*/

--- a/netqasm/sdk/connection.py
+++ b/netqasm/sdk/connection.py
@@ -205,6 +205,7 @@ class BaseNetQASMConnection(abc.ABC):
             connection=self,
             app_id=self._app_id,
             hardware_config=hardware_config,
+            log_config=log_config,
             compiler=compiler,
             return_arrays=return_arrays,
         )


### PR DESCRIPTION
Added the optional `log_config` argument to `Builder`. This fixes the otherwise empty pickle file produced by `BaseNetQASMConnection` on L409.

Also thanks to Ravi for helping to track this bug down.

FYI:
Removing L192 & L193 from `BaseNetQASMConnection`, because they are also present in `Builder` L248 & L249, results in the following error while running the tests:

```
--- Logging error ---
Traceback (most recent call last):
  File "/home/paul/.pyenv/versions/3.10.15/lib/python3.10/logging/__init__.py", line 1103, in emit
    stream.write(msg + self.terminator)
ValueError: I/O operation on closed file.
Call stack:
  File "/home/paul/.pyenv/versions/3.10.15/lib/python3.10/threading.py", line 973, in _bootstrap
    self._bootstrap_inner()
  File "/home/paul/.pyenv/versions/3.10.15/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/home/paul/.pyenv/versions/3.10.15/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
^CException ignored in: <module 'threading' from '/home/paul/.pyenv/versions/3.10.15/lib/python3.10/threading.py'>
Traceback (most recent call last):
  File "/home/paul/github/qutech-delft/netqasm/.venv3.10/squidasm/squidasm/run/multithread/runtime_mgr.py", line 125, in backend_thread
    ns.sim_run()
  File "/home/paul/.pyenv/versions/3.10.15/lib/python3.10/threading.py", line 1567, in _shutdown
  File "/home/paul/github/qutech-delft/netqasm/.venv3.10/lib/python3.10/site-packages/netsquid/util/simtools.py", line 278, in sim_run
    _simengine.run()
    lock.acquire()
  File "src/cysignals/signals.pyx", line 341, in cysignals.signals.python_check_interrupt
  File "/home/paul/github/qutech-delft/netqasm/.venv3.10/squidasm/squidasm/nqasm/qnodeos.py", line 147, in run
    ev = self._get_next_task_event()
  File "/home/paul/github/qutech-delft/netqasm/.venv3.10/squidasm/squidasm/nqasm/qnodeos.py", line 185, in _get_next_task_event
    self._logger.debug("No more subroutine tasks")
Message: 'No more subroutine tasks'
Arguments: ()
```