### PR TITLE
Add axes selection to Qubit.measure

### DIFF
--- a/netqasm/lang/encoding.py
+++ b/netqasm/lang/encoding.py
@@ -38,7 +38,7 @@ REG_NAME_BITS = 2
 # Num bits in register index
 REG_INDEX_BITS = 4
 
-COMMAND_BYTES = 7
+COMMAND_BYTES = 8
 
 PADDING_FIELD = "padding"
 
@@ -192,7 +192,7 @@ class RegRegImmImmCommand(Command):
     )
 
 
-class RegRegImm4Command(Command):
+class RegRegImm5Command(Command):
     _fields_ = add_padding(
         [
             ("reg0", Register),
@@ -201,6 +201,7 @@ class RegRegImm4Command(Command):
             ("imm1", IMMEDIATE),
             ("imm2", IMMEDIATE),
             ("imm3", IMMEDIATE),
+            ("imm4", IMMEDIATE),
         ]
     )
 
@@ -350,7 +351,7 @@ COMMANDS = [
     MeasCommand,
     RegImmImmCommand,
     RegRegImmImmCommand,
-    RegRegImm4Command,
+    RegRegImm5Command,
     RegRegRegCommand,
     ImmCommand,
     ImmImmCommand,

--- a/netqasm/lang/instr/base.py
+++ b/netqasm/lang/instr/base.py
@@ -286,9 +286,9 @@ class RegRegImmImmInstruction(NetQASMInstruction):
 
 
 @dataclass
-class RegRegImm4Instruction(NetQASMInstruction):
+class RegRegImm5Instruction(NetQASMInstruction):
     """
-    An instruction with 2 Register operands followed by 4 Immediate operands.
+    An instruction with 2 Register operands followed by 5 Immediate operands.
     """
 
     reg0: Register = None  # type: ignore
@@ -297,14 +297,23 @@ class RegRegImm4Instruction(NetQASMInstruction):
     imm1: Immediate = None  # type: ignore
     imm2: Immediate = None  # type: ignore
     imm3: Immediate = None  # type: ignore
+    imm4: Immediate = None  # type: ignore
 
     @property
     def operands(self) -> List[Operand]:
-        return [self.reg0, self.reg1, self.imm0, self.imm1, self.imm2, self.imm3]
+        return [
+            self.reg0,
+            self.reg1,
+            self.imm0,
+            self.imm1,
+            self.imm2,
+            self.imm3,
+            self.imm4,
+        ]
 
     @classmethod
     def deserialize_from(cls, raw: bytes):
-        c_struct = encoding.RegRegImm4Command.from_buffer_copy(raw)
+        c_struct = encoding.RegRegImm5Command.from_buffer_copy(raw)
         assert c_struct.id == cls.id
         reg0 = Register.from_raw(c_struct.reg0)
         reg1 = Register.from_raw(c_struct.reg1)
@@ -312,10 +321,13 @@ class RegRegImm4Instruction(NetQASMInstruction):
         imm1 = Immediate(value=c_struct.imm1)
         imm2 = Immediate(value=c_struct.imm2)
         imm3 = Immediate(value=c_struct.imm3)
-        return cls(reg0=reg0, reg1=reg1, imm0=imm0, imm1=imm1, imm2=imm2, imm3=imm3)
+        imm4 = Immediate(value=c_struct.imm4)
+        return cls(
+            reg0=reg0, reg1=reg1, imm0=imm0, imm1=imm1, imm2=imm2, imm3=imm3, imm4=imm4
+        )
 
     def serialize(self) -> bytes:
-        c_struct = encoding.RegRegImm4Command(
+        c_struct = encoding.RegRegImm5Command(
             id=self.id,
             reg0=self.reg0.cstruct,
             reg1=self.reg1.cstruct,
@@ -323,13 +335,14 @@ class RegRegImm4Instruction(NetQASMInstruction):
             imm1=self.imm1.value,
             imm2=self.imm2.value,
             imm3=self.imm3.value,
+            imm4=self.imm4.value,
         )
         return bytes(c_struct)
 
     @classmethod
     def from_operands(cls, operands: List[Union[Operand, int]]):
-        assert len(operands) == 6
-        reg0, reg1, imm0, imm1, imm2, imm3 = operands
+        assert len(operands) == 7
+        reg0, reg1, imm0, imm1, imm2, imm3, imm4 = operands
         assert isinstance(reg0, Register)
         assert isinstance(reg1, Register)
         assert isinstance(imm0, int) or isinstance(imm0, Immediate)
@@ -344,12 +357,17 @@ class RegRegImm4Instruction(NetQASMInstruction):
         assert isinstance(imm3, int) or isinstance(imm3, Immediate)
         if isinstance(imm3, int):
             imm3 = Immediate(value=imm3)
-        return cls(reg0=reg0, reg1=reg1, imm0=imm0, imm1=imm1, imm2=imm2, imm3=imm3)
+        assert isinstance(imm4, int) or isinstance(imm4, Immediate)
+        if isinstance(imm4, int):
+            imm4 = Immediate(value=imm4)
+        return cls(
+            reg0=reg0, reg1=reg1, imm0=imm0, imm1=imm1, imm2=imm2, imm3=imm3, imm4=imm4
+        )
 
     def _pretty_print(self):
         return (
             f"{self.mnemonic} {str(self.reg0)} {str(self.reg1)} {str(self.imm0)} "
-            f"{str(self.imm1)} {str(self.imm2)} {str(self.imm3)}"
+            f"{str(self.imm1)} {str(self.imm2)} {str(self.imm3)} {str(self.imm4)}"
         )
 
 

--- a/netqasm/lang/instr/core.py
+++ b/netqasm/lang/instr/core.py
@@ -455,7 +455,7 @@ class MeasInstruction(base.RegRegInstruction):
 
 
 @dataclass
-class MeasBasisInstruction(base.RegRegImm4Instruction):
+class MeasBasisInstruction(base.RegRegImm5Instruction):
     id: int = 41
     mnemonic: str = "meas_basis"
 
@@ -509,6 +509,14 @@ class MeasBasisInstruction(base.RegRegImm4Instruction):
     @angle_denom.setter
     def angle_denom(self, new_val: Immediate):
         self.imm3 = new_val
+
+    @property
+    def rotation_axes(self):
+        return self.imm4
+
+    @rotation_axes.setter
+    def rotation_axes(self, new_val: Immediate):
+        self.imm4 = new_val
 
 
 @dataclass

--- a/netqasm/lang/parsing/text.py
+++ b/netqasm/lang/parsing/text.py
@@ -535,7 +535,7 @@ for instr in [
     for index in [2, 3]:
         _REPLACE_CONSTANTS_EXCEPTION.append((instr, index))
 
-for index in [2, 3, 4, 5]:
+for index in [2, 3, 4, 5, 6]:
     _REPLACE_CONSTANTS_EXCEPTION.append((GenericInstr.MEAS_BASIS, index))
 
 

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -63,7 +63,7 @@ from netqasm.sdk.config import LogConfig
 from netqasm.sdk.constraint import SdkConstraint, ValueAtMostConstraint
 from netqasm.sdk.futures import Array, Future, RegFuture, T_CValue
 from netqasm.sdk.memmgr import MemoryManager
-from netqasm.sdk.qubit import FutureQubit, Qubit, QubitMeasureBasis
+from netqasm.sdk.qubit import FutureQubit, Qubit, QubitMeasureAxes, QubitMeasureBasis
 from netqasm.sdk.toolbox import get_angle_spec_from_float
 from netqasm.sdk.transpile import NVSubroutineTranspiler, SubroutineTranspiler
 from netqasm.typedefs import T_Cmd
@@ -1131,6 +1131,7 @@ class Builder:
         inplace: bool,
         basis: QubitMeasureBasis = QubitMeasureBasis.Z,
         rotations: Optional[Tuple[int, int, int]] = None,
+        axes: QubitMeasureAxes = QubitMeasureAxes.XYX,
     ) -> None:
         if isinstance(self._hardware_config, NVHardwareConfig):
             # If compiling for NV, only virtual ID 0 can be used to measure a qubit.
@@ -1146,20 +1147,48 @@ class Builder:
         denom = 4
 
         if rotations is not None:
-            x1, y, x2 = rotations
+            first, second, third = rotations
             meas_command = ICmd(
                 instruction=GenericInstr.MEAS_BASIS,
-                operands=[qubit_reg, outcome_reg, x1, y, x2, denom],
+                operands=[qubit_reg, outcome_reg, first, second, third, denom, axes],
             )
         elif basis == QubitMeasureBasis.X:
+            first, second, third = {
+                QubitMeasureAxes.XYX: (0, 24, 0),
+                QubitMeasureAxes.YZY: (24, 0, 0),
+                QubitMeasureAxes.ZXZ: (0, 24, 8),
+            }[axes]
+
             meas_command = ICmd(
                 instruction=GenericInstr.MEAS_BASIS,
-                operands=[qubit_reg, outcome_reg, 0, 24, 0, denom],  # -pi/2 Y rotation
+                operands=[
+                    qubit_reg,
+                    outcome_reg,
+                    first,
+                    second,
+                    third,
+                    denom,
+                    axes,
+                ],  # -pi/2 Y rotation
             )
         elif basis == QubitMeasureBasis.Y:
+            first, second, third = {
+                QubitMeasureAxes.XYX: (8, 0, 0),
+                QubitMeasureAxes.YZY: (8, 24, 0),
+                QubitMeasureAxes.ZXZ: (0, 8, 0),
+            }[axes]
+
             meas_command = ICmd(
                 instruction=GenericInstr.MEAS_BASIS,
-                operands=[qubit_reg, outcome_reg, 8, 0, 0, denom],  # pi/2 X rotation
+                operands=[
+                    qubit_reg,
+                    outcome_reg,
+                    first,
+                    second,
+                    third,
+                    denom,
+                    axes,
+                ],  # pi/2 X rotation
             )
         else:
             meas_command = ICmd(

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -5,7 +5,7 @@ as handles to in-memory qubits.
 """
 from __future__ import annotations
 
-from enum import Enum, auto
+from enum import Enum, IntEnum, auto
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 from netqasm.lang.ir import GenericInstr
@@ -26,6 +26,12 @@ class QubitMeasureBasis(Enum):
     X = 0
     Y = auto()
     Z = auto()
+
+
+class QubitMeasureAxes(IntEnum):
+    XYX = 0
+    YZY = 1
+    ZXZ = 2
 
 
 class Qubit:
@@ -174,6 +180,7 @@ class Qubit:
         store_array: bool = True,
         basis: QubitMeasureBasis = QubitMeasureBasis.Z,
         basis_rotations: Optional[Tuple[int, int, int]] = None,
+        basis_rotation_axes: QubitMeasureAxes = QubitMeasureAxes.XYX,
     ) -> Union[Future, RegFuture]:
         """
         Measure the qubit in the standard basis and get the measurement outcome.
@@ -189,12 +196,12 @@ class Qubit:
             Default is Z. Ignored if `basis_rotations` is not None.
         :param basis_rotations: rotations to apply before measuring in the
             Z-basis. This can be used to specify arbitrary measurement bases.
-            The 3 values are interpreted as 3 rotation angles, for an X- Y-, and
-            another X-rotation, respectively. Each angle is interpreted as a
-            multiple of pi/16. For example, if `basis_rotations` is (8, 0, 0),
-            an X-rotation is applied with angle 8*pi/16 = pi/2 radians, followed
+            The 3 values are interpreted as 3 rotation angles, around the axes specified by basis_rotation_axes.
+            Each angle is interpreted as a multiple of pi/16. For example, if `basis_rotations` is (8, 0, 0) and
+            basis_rotation_axes is XYX, an X-rotation is applied with angle 8*pi/16 = pi/2 radians, followed
             by a Y-rotation of angle 0 and an X-rotation of angle 0. Finally,
             the measurement is done in the Z-basis.
+        :param basis_rotation_axes: Axes around which the rotations from basis_rotations should be performed, in order.
         :return: the Future representing the measurement outcome. It is a
             `Future` if
         the result is in an array (default) or `RegFuture` if the result is in a
@@ -215,6 +222,7 @@ class Qubit:
             inplace=inplace,
             basis=basis,
             rotations=basis_rotations,
+            axes=basis_rotation_axes,
         )
 
         if not inplace:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1044,7 +1044,7 @@ def test_measure_basis():
 
         [meas_basis] = inspector.find_instr(GenericInstr.MEAS_BASIS)
         # check if rotations are correct
-        assert meas_basis.operands[2:] == [0, 24, 0, 4]  # skip register operands
+        assert meas_basis.operands[2:] == [0, 24, 0, 4, 0]  # skip register operands
 
         compiled_subroutine = conn.builder.subrt_compile_subroutine(presubroutine)
         print(compiled_subroutine)
@@ -1062,7 +1062,7 @@ def test_measure_basis_rotation():
 
         [meas_basis] = inspector.find_instr(GenericInstr.MEAS_BASIS)
         # check if rotations are correct
-        assert meas_basis.operands[2:] == [3, 4, 5, 4]  # skip register operands
+        assert meas_basis.operands[2:] == [3, 4, 5, 4, 0]  # skip register operands
 
         compiled_subroutine = conn.builder.subrt_compile_subroutine(presubroutine)
         print(compiled_subroutine)

--- a/tests/test_parsing/test_binary.py
+++ b/tests/test_parsing/test_binary.py
@@ -86,7 +86,7 @@ qfree Q0
 
 def test_deserialize_subroutine():
     metadata = b"\x00\x00\x00\x00"
-    cphase_gate = b"\x1F\x00\x00\x00\x00\x00\x00"
+    cphase_gate = b"\x1F\x00\x00\x00\x00\x00\x00\x00"
     raw = bytes(metadata + cphase_gate)
     print(raw)
     subroutine = deserialize(raw)


### PR DESCRIPTION
For experiments in the lab, it is important to be able to specify the axes that a pre-measurement gate should rotate around.
This PR adds this option, defaulting to the original XYX.

Note that this does not add support for specifying axes for `EprSocket.create_measure`, as this PR is made under a time limit and this is not needed for the experiments in the lab.
If this change gets approved by Bart, we can look at adding that functionality as well.