### PR TITLE
Adapt external.py to upcoming changes in QNodeOS 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ htmlcov/
 .coverage
 .idea/*
 .vscode/*
+
+venv/

--- a/netqasm/examples/sdk_scripts/rsp.py
+++ b/netqasm/examples/sdk_scripts/rsp.py
@@ -58,6 +58,8 @@ def run_server(use_rsp: bool) -> Dict[str, Any]:
             epr.H()
             outcome = epr.measure(store_array=False)
             subroutine = conn.compile()
+            if subroutine is None:
+                raise RuntimeError("Failed to compile subroutine")
 
             delta1 = float(csocket.recv())
             numerator = int(delta1 / (math.pi / 16))

--- a/netqasm/sdk/external.py
+++ b/netqasm/sdk/external.py
@@ -14,6 +14,8 @@ had to specify this concrete name. This allows the same application code to be u
 with different implementations of `NetQASMConnection`.
 """
 
+# mypy: disable-error-code="no-redef"
+
 from netqasm.runtime.settings import Simulator, get_is_using_hardware, get_simulator
 
 simulator = get_simulator()
@@ -21,30 +23,46 @@ is_using_hardware = get_is_using_hardware()
 
 if is_using_hardware:
     try:
-        from qnodeos.sdk.connection import (
-            QNodeOSConnection as NetQASMConnection,  # type: ignore
+        from qnodeos.connection import (
+            ABCQNodeOSConnection,
+            ApplicationRole,
+            ConnectionSpecification,
+            QNodeOSConnectionFactory,
+            TcpIPConnectionSpecification,
         )
-        from qnodeos.sdk.socket import Socket  # type: ignore
-
-        from netqasm.runtime.hardware import run_application  # type: ignore
+        from qnodeos.socket import (
+            ABCAppSocket,
+            AppSocketRole,
+            ClientAppSocket,
+            ServerAppSocket,
+        )
     except ModuleNotFoundError:
-        raise ModuleNotFoundError("to use QNodeOS , `qnodeos` needs to be installed")
+        raise ModuleNotFoundError("To use QNodeOS , `qnodeos` needs to be installed")
+
+    import warnings
+
+    from netqasm.runtime.hardware import run_application
+    from netqasm.sdk.classical_communication import ThreadSocket as Socket
+    from netqasm.sdk.connection import DebugConnection as NetQASMConnection
+
+    warnings.warn(
+        "QNodeOS has dropped support for `NetQASMConnection` and `Socket`."
+        " Use `qnodeos.connection.QNodeOSConnectionFactory` to create connections and"
+        " use `qnodeos.socket.[Client,Server]AppSocket` to replace `Socket`.",
+        category=DeprecationWarning,
+    )
+
+
 elif simulator == Simulator.NETSQUID:
     try:
-        from squidasm.nqasm.multithread import (
-            NetSquidConnection as NetQASMConnection,  # type: ignore
-        )
-        from squidasm.run.multithread.simulate import (
-            simulate_application,  # type: ignore
-        )
-        from squidasm.util.sim import get_qubit_state  # type: ignore
+        from squidasm.nqasm.multithread import NetSquidConnection as NetQASMConnection
+        from squidasm.run.multithread.simulate import simulate_application
+        from squidasm.util.sim import get_qubit_state
 
         from netqasm.sdk.classical_communication import (
-            ThreadBroadcastChannel as BroadcastChannel,  # type: ignore
+            ThreadBroadcastChannel as BroadcastChannel,
         )
-        from netqasm.sdk.classical_communication import (
-            ThreadSocket as Socket,  # type: ignore
-        )
+        from netqasm.sdk.classical_communication import ThreadSocket as Socket
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             f"to use {Simulator.NETSQUID.value} as simulator, `squidasm` needs to be installed"
@@ -52,14 +70,12 @@ elif simulator == Simulator.NETSQUID:
 elif simulator == Simulator.NETSQUID_SINGLE_THREAD:
     try:
         from squidasm.nqasm.singlethread.connection import (
-            NetSquidConnection as NetQASMConnection,  # type: ignore
+            NetSquidConnection as NetQASMConnection,
         )
-        from squidasm.nqasm.singlethread.csocket import (
-            NetSquidSocket as Socket,  # type: ignore
-        )
+        from squidasm.nqasm.singlethread.csocket import NetSquidSocket as Socket
 
         from netqasm.sdk.classical_communication import (
-            ThreadBroadcastChannel as BroadcastChannel,  # type: ignore
+            ThreadBroadcastChannel as BroadcastChannel,
         )
 
     except ModuleNotFoundError:
@@ -68,30 +84,22 @@ elif simulator == Simulator.NETSQUID_SINGLE_THREAD:
         )
 elif simulator == Simulator.SIMULAQRON:
     try:
-        from simulaqron.run.run import (
-            run_applications as simulate_application,  # type: ignore
-        )
-        from simulaqron.sdk.broadcast_channel import BroadcastChannel  # type: ignore
-        from simulaqron.sdk.connection import (
-            SimulaQronConnection as NetQASMConnection,  # type: ignore
-        )
-        from simulaqron.sdk.socket import Socket  # type: ignore
-        from simulaqron.sim_util import get_qubit_state  # type: ignore
+        from simulaqron.run.run import run_applications as simulate_application
+        from simulaqron.sdk.broadcast_channel import BroadcastChannel
+        from simulaqron.sdk.connection import SimulaQronConnection as NetQASMConnection
+        from simulaqron.sdk.socket import Socket
+        from simulaqron.sim_util import get_qubit_state
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             f"to use {Simulator.SIMULAQRON.value} as simulator, `simulaqron` needs to be installed"
         )
 elif simulator == Simulator.DEBUG:
-    from netqasm.runtime.debug import get_qubit_state  # type: ignore
     from netqasm.runtime.debug import run_application  # type: ignore
+    from netqasm.runtime.debug import get_qubit_state
     from netqasm.sdk.classical_communication import (
-        ThreadBroadcastChannel as BroadcastChannel,  # type: ignore
+        ThreadBroadcastChannel as BroadcastChannel,
     )
-    from netqasm.sdk.classical_communication import (
-        ThreadSocket as Socket,  # type: ignore
-    )
-    from netqasm.sdk.connection import (
-        DebugConnection as NetQASMConnection,  # type: ignore
-    )
+    from netqasm.sdk.classical_communication import ThreadSocket as Socket
+    from netqasm.sdk.connection import DebugConnection as NetQASMConnection
 else:
     raise ValueError(f"Unknown simulator {simulator}")

--- a/tests/test_transpiling.py
+++ b/tests/test_transpiling.py
@@ -24,7 +24,7 @@ def pad_single_matrix(m: np.ndarray, index: int, total: int) -> np.ndarray:
         if i == index:
             matrix = np.kron(matrix, m)
         else:
-            matrix = np.kron(matrix, np.eye(2))
+            matrix = np.kron(matrix, np.eye(2))  # type:ignore
     return matrix
 
 
@@ -41,7 +41,7 @@ def pad_controlled_single_matrix(
         if i == ctrl_index:
             matrix0 = np.kron(matrix0, np.array([[1, 0], [0, 0]]))
         else:
-            matrix0 = np.kron(matrix0, np.eye(2))
+            matrix0 = np.kron(matrix0, np.eye(2))  # type:ignore
 
     matrix1 = np.eye(1)
     for i in range(total):
@@ -50,7 +50,7 @@ def pad_controlled_single_matrix(
         elif i == target_index:
             matrix1 = np.kron(matrix1, m)
         else:
-            matrix1 = np.kron(matrix1, np.eye(2))
+            matrix1 = np.kron(matrix1, np.eye(2))  # type:ignore
 
     return matrix0 + matrix1
 
@@ -67,7 +67,7 @@ class SubroutineMatrix:
         self._matrix = np.eye(1)
         for i, id in enumerate(virt_ids):
             self._matrix_indices[id] = i
-            self._matrix = np.kron(self._matrix, np.eye(2))
+            self._matrix = np.kron(self._matrix, np.eye(2))  # type:ignore
 
     def apply_single_qubit_instr(self, instr_matrix: np.ndarray, virt_id: int):
         m = pad_single_matrix(


### PR DESCRIPTION
QNodeOS 2.0 will drop support for creating `QNodeOSConnection` objects directly, thus this PR modifies `external.py` to document this.
It should also be noted that `QNodeOSConnection` has had a required field in its constructor for a while now (`end_node`), that was not filled in code using `NetQASMConnection`, so this was already broken.
This change effectively makes the problem more visible, but does not solve it.

As for `Socket`, that class was defined as abstract in `qnodeos` code before.
We are dropping it from our code-base, so this moves the fix to `netqasm`, which imposes the requirement.