### PR TITLE
Update git hub python version

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - run: |
         make install-dev
         make lint
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - run: |
         make install-dev
         make tests
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - run: |
         make install-dev
         make examples

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.8
+        python-version: 3.10
     - run: |
         make install-dev
         make lint
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.8
+        python-version: 3.10
     - run: |
         make install-dev
         make tests
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.8
+        python-version: 3.10
     - run: |
         make install-dev
         make examples

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/simulaqron.yaml
+++ b/.github/workflows/simulaqron.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install simulaqron
       run: pip install simulaqron
     - name: Install netqasm

--- a/.github/workflows/simulaqron.yaml
+++ b/.github/workflows/simulaqron.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install simulaqron
       run: pip install simulaqron
     - name: Install netqasm

--- a/.github/workflows/squidasm.yaml
+++ b/.github/workflows/squidasm.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install netqasm
       run: make install-dev
     - name: Install squidasm
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install netqasm
       run: make install-dev
     - name: Install squidasm

--- a/.github/workflows/squidasm.yaml
+++ b/.github/workflows/squidasm.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install netqasm
       run: make install-dev
     - name: Install squidasm
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@master
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Install netqasm
       run: make install-dev
     - name: Install squidasm

--- a/netqasm/util/quantum_gates.py
+++ b/netqasm/util/quantum_gates.py
@@ -51,7 +51,7 @@ def get_controlled_rotation_matrix(axis, angle) -> np.ndarray:
     inv_controlled_gate = np.kron(ctrl_zero, target_pos) + np.kron(ctrl_one, np.eye(2))
     controlled_gate = np.kron(ctrl_one, target_neg) + np.kron(ctrl_zero, np.eye(2))
 
-    return inv_controlled_gate @ controlled_gate
+    return inv_controlled_gate @ controlled_gate  # type: ignore
 
 
 def gate_to_matrix(instr, angle=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description_content_type = text/markdown
 license = MIT
 home_page = https://github.com/QuTech-Delft/netqasm
 url = https://github.com/QuTech-Delft/netqasm
-python_requires = >=3.7
+python_requires = >=3.10, <3.13
 
 [options]
 install_requires = 
@@ -22,7 +22,7 @@ install_requires =
 dev =
     pytest >=7.1, <8.0
     types-PyYAML >=6.0, <7.0
-    flake8 >=4.0, <5.0
+    flake8 >=4.0
     isort >=5.10, <5.11
     black >=22.3, <22.4
     mypy >=0.950


### PR DESCRIPTION
This small PR tackles a two things: Updates the python version used in github CI/CD pipeline, and updates the required python version to >=3.10 but < 3.13.
The CI/CD pipeline still fails on the Simulaqron backend tests. This is known, and to fix this, we need to upgrade the code on simulaqron, not this repo.