### PR TITLE
Correctly deactivate qubits when freeing them

### DIFF
--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -2111,7 +2111,7 @@ class Builder:
                     # Otherwise: free the qubits.
                     if not params.sequential:
                         for q in qubits:
-                            q.free()
+                            q.free(deactivate=False)
 
                 loop.set_cleanup_code(cleanup)
 

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -374,13 +374,17 @@ class Qubit:
         r"""Reset the qubit to the state \|0>."""
         self.builder._build_cmds_init_qubit(qubit_id=self.qubit_id)
 
-    def free(self) -> None:
+    def free(self, deactivate: bool = True) -> None:
         """
         Free the qubit and its virtual ID.
 
         After freeing, the underlying physical qubit can be used to store another state.
         """
         self.builder._build_cmds_qfree(qubit_id=self.qubit_id)
+        # Similarly as qubit measurements, which deactivate qubits if the measurement
+        # was not done in place, when freeing a qubit, we should *always* deactivate it.
+        if deactivate:
+            self._deactivate()
 
 
 class FutureQubit(Qubit):

--- a/tests/test_sdk/test_connection.py
+++ b/tests/test_sdk/test_connection.py
@@ -115,6 +115,72 @@ def test_simple():
     print(expected)
 
 
+def test_explicit_qfree():
+    set_log_level(logging.DEBUG)
+    with DebugConnection("Alice") as alice:
+        q0 = Qubit(alice)
+        q1 = Qubit(alice)  # noqa: F841
+        q0.free()
+        q2 = Qubit(alice)  # noqa: F841
+
+    # 4 messages: init, subroutine, stop app and stop backend
+    assert len(alice.storage) == 4
+    raw_subroutine = deserialize_message(raw=alice.storage[1]).subroutine
+    subroutine = deserialize_subroutine(raw_subroutine)
+    expected = Subroutine(
+        netqasm_version=NETQASM_VERSION,
+        app_id=0,
+        instructions=[
+            instructions.core.SetInstruction(
+                reg=Register(RegisterName.Q, 0),
+                imm=Immediate(0),
+            ),
+            instructions.core.QAllocInstruction(
+                reg=Register(RegisterName.Q, 0),
+            ),
+            instructions.core.InitInstruction(
+                reg=Register(RegisterName.Q, 0),
+            ),
+            instructions.core.SetInstruction(
+                reg=Register(RegisterName.Q, 0),
+                imm=Immediate(1),
+            ),
+            instructions.core.QAllocInstruction(
+                reg=Register(RegisterName.Q, 0),
+            ),
+            instructions.core.InitInstruction(
+                reg=Register(RegisterName.Q, 0),
+            ),
+            # Free Q0
+            instructions.core.SetInstruction(
+                reg=Register(RegisterName.Q, 0),
+                imm=Immediate(0),
+            ),
+            instructions.core.QFreeInstruction(
+                reg=Register(RegisterName.Q, 0),
+            ),
+            # Since we released qubit #0, we expect the next instruction
+            # ot use qubit ID #0
+            instructions.core.SetInstruction(
+                reg=Register(RegisterName.Q, 0),
+                imm=Immediate(0),
+            ),
+            instructions.core.QAllocInstruction(
+                reg=Register(RegisterName.Q, 0),
+            ),
+            instructions.core.InitInstruction(
+                reg=Register(RegisterName.Q, 0),
+            ),
+        ],
+    )
+    for instr, expected_instr in zip(subroutine.instructions, expected.instructions):
+        print(repr(instr))
+        print(repr(expected_instr))
+        assert instr == expected_instr
+    print(subroutine)
+    print(expected)
+
+
 def test_rotations():
     set_log_level(logging.DEBUG)
     with DebugConnection("Alice") as alice:


### PR DESCRIPTION
I detected a bug on the "free" operation of qubits, which might lead to the execution environment think that the subroutines uses more physical qubits than the ones available:
The code:
```
q0 = Qubit(alice)
q1 = Qubit(alice)
q0.free()
q2 = Qubit(alice)
```
compiles to the following NetQASM subroutine:
   0    () set Q0 0
   1    () qalloc Q0
   2    () init Q0
   3    () set Q0 1
   4    () qalloc Q0
   5    () init Q0
   6    () set Q0 0
   7    () qfree Q0
   8    () set Q0 2    <---- This is incorrect; (virtual) qubit ID 0 is available at this point
   9    () qalloc Q0
  10    () init Q0

This PR addresses the issue.