### PR TITLE
Add support for MOV and SWP commands

### DIFF
--- a/netqasm/lang/instr/flavour.py
+++ b/netqasm/lang/instr/flavour.py
@@ -96,6 +96,7 @@ class VanillaFlavour(Flavour):
             vanilla.CnotInstruction,
             vanilla.CphaseInstruction,
             vanilla.MovInstruction,
+            vanilla.SwpInstruction,
         ]
 
     def __init__(self):
@@ -111,6 +112,8 @@ class NVFlavour(Flavour):
             nv.RotZInstruction,
             nv.ControlledRotXInstruction,
             nv.ControlledRotYInstruction,
+            nv.MovInstruction,
+            nv.SwpInstruction,
         ]
 
     def __init__(self):

--- a/netqasm/lang/instr/nv.py
+++ b/netqasm/lang/instr/nv.py
@@ -75,3 +75,36 @@ class ControlledRotYInstruction(core.ControlledRotationInstruction):
         axis = [1, 0, 0]
         angle = self.angle_num.value * np.pi / 2**self.angle_denom.value
         return get_rotation_matrix(axis, angle)
+
+
+@dataclass
+class MovInstruction(core.TwoQubitInstruction):
+    """Move source qubit to target qubit (target is overwritten)"""
+
+    id: int = 51
+    mnemonic: str = "mov"
+
+    def to_matrix(self) -> np.ndarray:
+        # NOTE: Currently this is represented as a full SWAP.
+        return np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+    def to_matrix_target_only(self) -> np.ndarray:  # type: ignore
+        # NOTE: The mov instruction is not meant to be viewed as control-target gate.
+        # Therefore, it is OK to not explicitly define a matrix.
+        return None  # type: ignore
+
+
+@dataclass
+class SwpInstruction(core.TwoQubitInstruction):
+    """Swap the states of two qubits"""
+
+    id: int = 52
+    mnemonic: str = "swp"
+
+    def to_matrix(self) -> np.ndarray:
+        return np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+    def to_matrix_target_only(self) -> np.ndarray:  # type: ignore
+        # NOTE: The swp instruction is not meant to be viewed as control-target gate.
+        # Therefore, it is OK to not explicitly define a matrix.
+        return None  # type: ignore

--- a/netqasm/lang/instr/vanilla.py
+++ b/netqasm/lang/instr/vanilla.py
@@ -137,7 +137,7 @@ class CphaseInstruction(core.TwoQubitInstruction):
 class MovInstruction(core.TwoQubitInstruction):
     """Move source qubit to target qubit (target is overwritten)"""
 
-    id: int = 41
+    id: int = 51
     mnemonic: str = "mov"
 
     def to_matrix(self) -> np.ndarray:
@@ -146,5 +146,21 @@ class MovInstruction(core.TwoQubitInstruction):
 
     def to_matrix_target_only(self) -> np.ndarray:  # type: ignore
         # NOTE: The mov instruction is not meant to be viewed as control-target gate.
+        # Therefore, it is OK to not explicitly define a matrix.
+        return None  # type: ignore
+
+
+@dataclass
+class SwpInstruction(core.TwoQubitInstruction):
+    """Swap the states of two qubits"""
+
+    id: int = 52
+    mnemonic: str = "swp"
+
+    def to_matrix(self) -> np.ndarray:
+        return np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+
+    def to_matrix_target_only(self) -> np.ndarray:  # type: ignore
+        # NOTE: The swp instruction is not meant to be viewed as control-target gate.
         # Therefore, it is OK to not explicitly define a matrix.
         return None  # type: ignore

--- a/netqasm/lang/ir.py
+++ b/netqasm/lang/ir.py
@@ -92,6 +92,9 @@ class GenericInstr(Enum):
     # Breakpoint
     BREAKPOINT = auto()
 
+    # Swap the state of two qubits
+    SWP = auto()
+
 
 class BreakpointAction(Enum):
     NOP = 0

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1122,9 +1122,11 @@ class Builder:
         self.subrt_add_pending_command(qubit_command)
 
     def _build_cmds_move_qubit(self, source: int, target: int) -> None:
-        # Moves a qubit from one position to another (assumes that target is free)
-        assert target not in [q.qubit_id for q in self._mem_mgr.get_active_qubits()]
-        self._build_cmds_new_qubit(target)
+        # Moves a qubit from one position to another.
+        if target not in [q.qubit_id for q in self._mem_mgr.get_active_qubits()]:
+            # If the target is free, allocate it.
+            self._build_cmds_new_qubit(target)
+        # Overwrite the state of the target qubit with the state of the source.
         self._build_cmds_two_qubit(GenericInstr.MOV, source, target)
         self._build_cmds_qfree(source)
 

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1130,6 +1130,12 @@ class Builder:
         self._build_cmds_two_qubit(GenericInstr.MOV, source, target)
         self._build_cmds_qfree(source)
 
+    def _build_cmds_swap_qubits(self, qubit1: int, qubit2: int) -> None:
+        # Swap the state of two qubits. Both qubits should be active.
+        assert qubit1 in [q.qubit_id for q in self._mem_mgr.get_active_qubits()]
+        assert qubit2 in [q.qubit_id for q in self._mem_mgr.get_active_qubits()]
+        self._build_cmds_two_qubit(GenericInstr.SWP, qubit1, qubit2)
+
     def _build_cmds_measure(
         self,
         qubit_id: int,

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -370,14 +370,7 @@ class Qubit:
             target_qubit_id=target.qubit_id,
         )
 
-    def swap(self, target: Qubit) -> None:
-        """Swap the state of the qubit with the state of another qubit.
-
-        :param target: target qubit to swap states with.
-        """
-        raise NotImplementedError()
-
-    def move(self, target: Qubit) -> None:
+    def move(self, target:Qubit)->None:
         """Move the state of the qubit to the target qubit,
         overwriting any state present in the target.
 
@@ -385,6 +378,15 @@ class Qubit:
         """
         self.builder._build_cmds_move_qubit(
             source=self.qubit_id, target=target.qubit_id
+        )
+
+    def swap(self, target: Qubit) -> None:
+        """Swap the state of the qubit with the state of another qubit.
+
+        :param target: target qubit to swap states with.
+        """
+        self.builder._build_cmds_swap_qubits(
+            qubit1=self.qubit_id, qubit2=target.qubit_id
         )
 
     def reset(self) -> None:

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -370,6 +370,23 @@ class Qubit:
             target_qubit_id=target.qubit_id,
         )
 
+    def swap(self, target: Qubit) -> None:
+        """Swap the state of the qubit with the state of another qubit.
+
+        :param target: target qubit to swap states with.
+        """
+        raise NotImplementedError()
+
+    def move(self, target: Qubit) -> None:
+        """Move the state of the qubit to the target qubit,
+        overwriting any state present in the target.
+
+        :param target: target qubit to move the state to.
+        """
+        self.builder._build_cmds_move_qubit(
+            source=self.qubit_id, target=target.qubit_id
+        )
+
     def reset(self) -> None:
         r"""Reset the qubit to the state \|0>."""
         self.builder._build_cmds_init_qubit(qubit_id=self.qubit_id)

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -370,7 +370,7 @@ class Qubit:
             target_qubit_id=target.qubit_id,
         )
 
-    def move(self, target:Qubit)->None:
+    def move(self, target: Qubit) -> None:
         """Move the state of the qubit to the target qubit,
         overwriting any state present in the target.
 

--- a/netqasm/sdk/transpile.py
+++ b/netqasm/sdk/transpile.py
@@ -8,7 +8,7 @@ flavour.
 import abc
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from netqasm.lang.instr import DebugInstruction, NetQASMInstruction, core, nv, vanilla
+from netqasm.lang.instr import NetQASMInstruction, core, nv, vanilla
 from netqasm.lang.instr.flavour import REIDSFlavour
 from netqasm.lang.operand import Immediate, Register, RegisterName
 from netqasm.lang.subroutine import Subroutine
@@ -51,77 +51,16 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
                 return reg
         raise RuntimeError("Could not find free register")
 
-    def swap(
-        self,
+    @staticmethod
+    def _swap(
         lineno: Optional[HostLine],
-        electron: Register,
-        carbon: Register,
+        reg0: Register,
+        reg1: Register,
     ) -> List[NetQASMInstruction]:
         """
-        Swap the states of the electron and a carbon.
-        See https://gitlab.tudelft.nl/qinc-wehner/netqasm/netqasm-docs/-/blob/master/nv-gates-docs.md
-        for the circuit.
+        Swap the states of two qubits.
         """
-        gates: List[NetQASMInstruction] = []
-
-        if self._debug:
-            gates += [DebugInstruction(text="begin SWAP")]
-
-        gates += [
-            nv.ControlledRotXInstruction(
-                lineno=lineno,
-                reg0=electron,
-                reg1=carbon,
-                imm0=Immediate(8),
-                imm1=Immediate(4),
-            ),
-            nv.RotXInstruction(
-                lineno=lineno, reg=electron, imm0=Immediate(24), imm1=Immediate(4)
-            ),
-            nv.RotYInstruction(
-                lineno=lineno, reg=electron, imm0=Immediate(16), imm1=Immediate(4)
-            ),
-            nv.RotZInstruction(
-                lineno=lineno, reg=carbon, imm0=Immediate(24), imm1=Immediate(4)
-            ),
-            nv.ControlledRotXInstruction(
-                lineno=lineno,
-                reg0=electron,
-                reg1=carbon,
-                imm0=Immediate(8),
-                imm1=Immediate(4),
-            ),
-            nv.RotXInstruction(
-                lineno=lineno, reg=electron, imm0=Immediate(8), imm1=Immediate(4)
-            ),
-            nv.RotYInstruction(
-                lineno=lineno, reg=electron, imm0=Immediate(8), imm1=Immediate(4)
-            ),
-            nv.RotXInstruction(
-                lineno=lineno, reg=carbon, imm0=Immediate(8), imm1=Immediate(4)
-            ),
-            nv.RotZInstruction(
-                lineno=lineno, reg=carbon, imm0=Immediate(8), imm1=Immediate(4)
-            ),
-            nv.ControlledRotXInstruction(
-                lineno=lineno,
-                reg0=electron,
-                reg1=carbon,
-                imm0=Immediate(8),
-                imm1=Immediate(4),
-            ),
-            nv.RotYInstruction(
-                lineno=lineno, reg=electron, imm0=Immediate(16), imm1=Immediate(4)
-            ),
-            nv.RotZInstruction(
-                lineno=lineno, reg=carbon, imm0=Immediate(16), imm1=Immediate(4)
-            ),
-        ]
-
-        if self._debug:
-            gates += [DebugInstruction(text="end SWAP")]
-
-        return gates
+        return [nv.SwpInstruction(lineno=lineno, reg0=reg0, reg1=reg1)]
 
     def transpile(self) -> Subroutine:
         """
@@ -196,89 +135,25 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
         self._subroutine.instructions = new_commands
         return self._subroutine
 
-    def _move_electron_carbon(
-        self, instr: vanilla.MovInstruction
-    ) -> List[NetQASMInstruction]:
-        """
-        See https://gitlab.tudelft.nl/qinc-wehner/netqasm/netqasm-docs/-/blob/master/nv-gates-docs.md
-        for the circuit.
-        """
-        electron = instr.reg0
-        carbon = instr.reg1
-        return [
-            nv.RotYInstruction(
-                lineno=instr.lineno, reg=electron, imm0=Immediate(8), imm1=Immediate(4)
-            ),
-            nv.ControlledRotYInstruction(
-                lineno=instr.lineno,
-                reg0=electron,
-                reg1=carbon,
-                imm0=Immediate(24),
-                imm1=Immediate(4),
-            ),
-            nv.RotXInstruction(
-                lineno=instr.lineno, reg=electron, imm0=Immediate(24), imm1=Immediate(4)
-            ),
-            nv.ControlledRotXInstruction(
-                lineno=instr.lineno,
-                reg0=electron,
-                reg1=carbon,
-                imm0=Immediate(8),
-                imm1=Immediate(4),
-            ),
-        ]
-
-    def _move_carbon_electron(
-        self, instr: vanilla.MovInstruction
-    ) -> List[NetQASMInstruction]:
-        """
-        See https://gitlab.tudelft.nl/qinc-wehner/netqasm/netqasm-docs/-/blob/master/nv-gates-docs.md
-        for the circuit.
-        """
-        electron = instr.reg1
-        carbon = instr.reg0
-        return [
-            nv.RotYInstruction(
-                lineno=instr.lineno, reg=electron, imm0=Immediate(8), imm1=Immediate(4)
-            ),
-            nv.ControlledRotYInstruction(
-                lineno=instr.lineno,
-                reg0=electron,
-                reg1=carbon,
-                imm0=Immediate(24),
-                imm1=Immediate(4),
-            ),
-            nv.RotXInstruction(
-                lineno=instr.lineno, reg=electron, imm0=Immediate(24), imm1=Immediate(4)
-            ),
-            nv.ControlledRotXInstruction(
-                lineno=instr.lineno,
-                reg0=electron,
-                reg1=carbon,
-                imm0=Immediate(8),
-                imm1=Immediate(4),
-            ),
-            nv.RotYInstruction(
-                lineno=instr.lineno, reg=electron, imm0=Immediate(24), imm1=Immediate(4)
-            ),
-            nv.RotZInstruction(
-                lineno=instr.lineno, reg=electron, imm0=Immediate(24), imm1=Immediate(4)
-            ),
-        ]
-
     def _handle_two_qubit_gate(
         self, instr: core.TwoQubitInstruction
     ) -> List[NetQASMInstruction]:
+        # These gates can have register arguments that have values unknown at transpile-time.
+        # They are thus handled before trying to resolve the register values.
+        if isinstance(instr, vanilla.MovInstruction):
+            return [
+                nv.MovInstruction(lineno=instr.lineno, reg0=instr.reg0, reg1=instr.reg1)
+            ]
+        elif isinstance(instr, vanilla.SwpInstruction):
+            return self._swap(lineno=instr.lineno, reg0=instr.reg0, reg1=instr.reg1)
+
         try:
             qubit_id0 = self.get_reg_value(instr.reg0).value
             qubit_id1 = self.get_reg_value(instr.reg1).value
-        except KeyError:
-            # Register values are not known at transpile time.
-            # We may assume that this is a MOV operation from the communication
-            # qubit to a memory qubit. (This is the only time a gate uses
-            # operands that are not known at transpile time.)
-            assert isinstance(instr, vanilla.MovInstruction)
-            return self._move_electron_carbon(instr)
+        except KeyError as e:
+            raise AssertionError(
+                "Value of register unknown at transpile-time for two-qubit gate"
+            ) from e
 
         assert qubit_id0 != qubit_id1
 
@@ -300,13 +175,6 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
                 return self._map_cphase_electron_carbon(swapped)
             else:
                 return self._map_cphase_carbon_carbon(instr)
-        elif isinstance(instr, vanilla.MovInstruction):
-            if qubit_id0 == 0 and qubit_id1 != 0:
-                return self._move_electron_carbon(instr)
-            elif qubit_id0 != 0 and qubit_id1 == 0:
-                return self._move_carbon_electron(instr)
-            else:
-                raise RuntimeError(f"Cannot move qubit {qubit_id0} to {qubit_id1}")
         else:
             raise ValueError(
                 f"Don't know how to map instruction {instr} of type {type(instr)}"
@@ -361,9 +229,9 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
 
         result: List[NetQASMInstruction] = [set_electron]
         result += (
-            self.swap(instr.lineno, electron, carbon)
+            self._swap(instr.lineno, electron, carbon)
             + self._map_cphase_electron_carbon(instr)
-            + self.swap(instr.lineno, electron, carbon)
+            + self._swap(instr.lineno, electron, carbon)
         )
         return result
 
@@ -452,9 +320,9 @@ class NVSubroutineTranspiler(SubroutineTranspiler):
 
         result: List[NetQASMInstruction] = [set_electron]
         result += (
-            self.swap(instr.lineno, electron, carbon)
+            self._swap(instr.lineno, electron, carbon)
             + self._map_cnot_electron_carbon(instr)
-            + self.swap(instr.lineno, electron, carbon)
+            + self._swap(instr.lineno, electron, carbon)
         )
         return result
 

--- a/tests/test_parsing/test_binary.py
+++ b/tests/test_parsing/test_binary.py
@@ -1,3 +1,10 @@
+from netqasm.lang.instr.core import (
+    ArrayInstruction,
+    MeasBasisInstruction,
+    RetArrInstruction,
+    SetInstruction,
+    StoreInstruction,
+)
 from netqasm.lang.instr.vanilla import CphaseInstruction
 from netqasm.lang.parsing import deserialize, parse_text_subroutine
 
@@ -97,6 +104,61 @@ def test_deserialize_subroutine():
 
     subroutine2 = deserialize(raw)
     print(subroutine2)
+
+
+def test_meas_base_binary_subroutine():
+    # TODO - There migth be a bug in the deserialization:
+    # Subroutine
+    #   set R0 1
+    #   array R0 @2
+    #   set Q0 0
+    #   meas_basis Q0 M0 0 24 0 4
+    #   set R0 0
+    #   store M0 @2[R0]
+    #   ret_arr @2
+    # EndSubroutine
+    # deserializes as:
+    # Subroutine
+    #   set R0 1
+    #   array R0 @2
+    #   set Q0 0
+    #   mov Q0 M0 ### This should be meas_basis... `meas_basis` and `mov` share the same id: "#40 or #41"
+    #   set R0 0
+    #   store M0 @2[R0]
+    #   ret_arr @2
+    # EndSubroutine
+    subroutine = """
+# NETQASM 0.0
+# APPID 0
+  set R0 1
+  array R0 @2
+  set Q0 0
+  meas_basis Q0 M0 0 24 0 4
+  set R0 0
+  store M0 @2[R0]
+  ret_arr @2
+"""
+    parsed_subroutine = parse_text_subroutine(subroutine)
+    print(f"parsed_subroutine: {parsed_subroutine}")
+    assert isinstance(parsed_subroutine.instructions[0], SetInstruction)
+    assert isinstance(parsed_subroutine.instructions[1], ArrayInstruction)
+    assert isinstance(parsed_subroutine.instructions[2], SetInstruction)
+    assert isinstance(parsed_subroutine.instructions[3], MeasBasisInstruction)
+    assert isinstance(parsed_subroutine.instructions[4], SetInstruction)
+    assert isinstance(parsed_subroutine.instructions[5], StoreInstruction)
+    assert isinstance(parsed_subroutine.instructions[6], RetArrInstruction)
+    bin_subroutine = bytes(parsed_subroutine)
+    print(f"binary subroutine: {bin_subroutine}")
+
+    deserialized_subroutine = deserialize(bin_subroutine)
+    print(f"deserialized subroutine: {deserialized_subroutine}")
+    assert isinstance(deserialized_subroutine.instructions[0], SetInstruction)
+    assert isinstance(deserialized_subroutine.instructions[1], ArrayInstruction)
+    assert isinstance(deserialized_subroutine.instructions[2], SetInstruction)
+    assert isinstance(deserialized_subroutine.instructions[3], MeasBasisInstruction)
+    assert isinstance(deserialized_subroutine.instructions[4], SetInstruction)
+    assert isinstance(deserialized_subroutine.instructions[5], StoreInstruction)
+    assert isinstance(deserialized_subroutine.instructions[6], RetArrInstruction)
 
 
 if __name__ == "__main__":

--- a/tests/test_parsing/test_binary.py
+++ b/tests/test_parsing/test_binary.py
@@ -107,26 +107,6 @@ def test_deserialize_subroutine():
 
 
 def test_meas_base_binary_subroutine():
-    # TODO - There migth be a bug in the deserialization:
-    # Subroutine
-    #   set R0 1
-    #   array R0 @2
-    #   set Q0 0
-    #   meas_basis Q0 M0 0 24 0 4
-    #   set R0 0
-    #   store M0 @2[R0]
-    #   ret_arr @2
-    # EndSubroutine
-    # deserializes as:
-    # Subroutine
-    #   set R0 1
-    #   array R0 @2
-    #   set Q0 0
-    #   mov Q0 M0 ### This should be meas_basis... `meas_basis` and `mov` share the same id: "#40 or #41"
-    #   set R0 0
-    #   store M0 @2[R0]
-    #   ret_arr @2
-    # EndSubroutine
     subroutine = """
 # NETQASM 0.0
 # APPID 0
@@ -165,3 +145,4 @@ if __name__ == "__main__":
     test()
     test_rotations()
     test_deserialize_subroutine()
+    test_meas_base_binary_subroutine()

--- a/tests/test_transpiling.py
+++ b/tests/test_transpiling.py
@@ -221,6 +221,8 @@ t Q0
 rot_x Q0 1 2
 rot_y Q0 1 2
 rot_z Q0 1 2
+mov Q0 Q1
+swp Q0 Q1
 """
     original_subroutine = parse_text_subroutine(text_subroutine)
     print(f"before transpiling: {original_subroutine}")
@@ -286,6 +288,9 @@ def test_transpiling_nv_using_sdk():
         q.rot_X(n=1, d=2)
         q.rot_Y(n=1, d=2)
         q.rot_Z(n=1, d=2)
+        q2 = Qubit(alice)
+        q.move(q2)
+        q.swap(q2)
 
     assert len(alice.storage) == 4
     raw_subroutine = deserialize_message(raw=alice.storage[1]).subroutine

--- a/tests/test_transpiling.py
+++ b/tests/test_transpiling.py
@@ -179,7 +179,7 @@ def _subroutine_as_matrix(subroutine: Subroutine) -> np.ndarray:
         set Q0 0
         set Q1 1
         set Q2 2
-        cphase Q1 Q2
+        cphase Q0 Q1
         h Q1
         cnot Q2 Q0
         """


### PR DESCRIPTION
This PR adds support for qubit move (MOV) and swap (SWP) commands to NetQASM.
These commands were previously discussed as necessary parts of the language, but had yet to be implemented.