### PR TITLE
Fix qubit not getting freed in memory manager after move

### DIFF
--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1128,7 +1128,6 @@ class Builder:
             self._build_cmds_new_qubit(target)
         # Overwrite the state of the target qubit with the state of the source.
         self._build_cmds_two_qubit(GenericInstr.MOV, source, target)
-        self._build_cmds_qfree(source)
 
     def _build_cmds_swap_qubits(self, qubit1: int, qubit2: int) -> None:
         # Swap the state of two qubits. Both qubits should be active.

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -379,6 +379,7 @@ class Qubit:
         self.builder._build_cmds_move_qubit(
             source=self.qubit_id, target=target.qubit_id
         )
+        self.free()
 
     def swap(self, target: Qubit) -> None:
         """Swap the state of the qubit with the state of another qubit.

--- a/tests/test_transpiling.py
+++ b/tests/test_transpiling.py
@@ -290,6 +290,7 @@ def test_transpiling_nv_using_sdk():
         q.rot_Z(n=1, d=2)
         q2 = Qubit(alice)
         q.move(q2)
+        q = Qubit(alice)
         q.swap(q2)
 
     assert len(alice.storage) == 4


### PR DESCRIPTION
This was a bug where the memory manager would not get notified of the source qubit being free after a move.