### PR TITLE
Remove explicit moves from Qubit

### DIFF
--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1129,6 +1129,12 @@ class Builder:
         # Overwrite the state of the target qubit with the state of the source.
         self._build_cmds_two_qubit(GenericInstr.MOV, source, target)
 
+        # Free source qubit
+        for qubit in self._mem_mgr.get_active_qubits():
+            if qubit.qubit_id == source:
+                qubit.free()
+                break
+
     def _build_cmds_swap_qubits(self, qubit1: int, qubit2: int) -> None:
         # Swap the state of two qubits. Both qubits should be active.
         assert qubit1 in [q.qubit_id for q in self._mem_mgr.get_active_qubits()]

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1122,18 +1122,11 @@ class Builder:
         self.subrt_add_pending_command(qubit_command)
 
     def _build_cmds_move_qubit(self, source: int, target: int) -> None:
-        # Moves a qubit from one position to another.
-        if target not in [q.qubit_id for q in self._mem_mgr.get_active_qubits()]:
-            # If the target is free, allocate it.
-            self._build_cmds_new_qubit(target)
-        # Overwrite the state of the target qubit with the state of the source.
+        # Moves a qubit from one position to another (assumes that target is free)
+        assert target not in [q.qubit_id for q in self._mem_mgr.get_active_qubits()]
+        self._build_cmds_new_qubit(target)
         self._build_cmds_two_qubit(GenericInstr.MOV, source, target)
-
-        # Free source qubit
-        for qubit in self._mem_mgr.get_active_qubits():
-            if qubit.qubit_id == source:
-                qubit.free()
-                break
+        self._build_cmds_qfree(source)
 
     def _build_cmds_swap_qubits(self, qubit1: int, qubit2: int) -> None:
         # Swap the state of two qubits. Both qubits should be active.

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -370,16 +370,6 @@ class Qubit:
             target_qubit_id=target.qubit_id,
         )
 
-    def move(self, target: Qubit) -> None:
-        """Move the state of the qubit to the target qubit,
-        overwriting any state present in the target.
-
-        :param target: target qubit to move the state to.
-        """
-        self.builder._build_cmds_move_qubit(
-            source=self.qubit_id, target=target.qubit_id
-        )
-
     def swap(self, target: Qubit) -> None:
         """Swap the state of the qubit with the state of another qubit.
 

--- a/netqasm/sdk/qubit.py
+++ b/netqasm/sdk/qubit.py
@@ -379,7 +379,6 @@ class Qubit:
         self.builder._build_cmds_move_qubit(
             source=self.qubit_id, target=target.qubit_id
         )
-        self.free()
 
     def swap(self, target: Qubit) -> None:
         """Swap the state of the qubit with the state of another qubit.

--- a/tests/test_transpiling.py
+++ b/tests/test_transpiling.py
@@ -289,8 +289,6 @@ def test_transpiling_nv_using_sdk():
         q.rot_Y(n=1, d=2)
         q.rot_Z(n=1, d=2)
         q2 = Qubit(alice)
-        q.move(q2)
-        q = Qubit(alice)
         q.swap(q2)
 
     assert len(alice.storage) == 4


### PR DESCRIPTION
Previously, we introduced the possibility to explicitly move a `Qubit` to another `Qubit`.
Unfortunately, this change does not work with `netqasm`s lack of a cohesive quantum memory management paradigm.
After extensive discussion, it was decided that removing explicit moves is the only feasible solution to this problem at the moment, as any other solution would require a rewrite of significant parts of `netqasm`.

Thus, this PR reverts the addition of explicit moves.
The back-end still uses implicit moves where needed.
Users who require an explicit move for whatever reason can instead use a swap.