### PR TITLE
Add condition on moving qubits to memory to having memory qubits

### DIFF
--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1902,6 +1902,11 @@ class Builder:
             and self._hardware_config.comm_qubit_count == 1
         )
 
+        has_mem_qubits: bool = (
+                self._hardware_config is not None
+                and self._hardware_config.mem_qubit_count > 0
+        )
+
         # If there is a post routine, handle pairs one by one.
         # If there is only one comm qubit, handle pairs one by one.
         if params.post_routine is not None or single_comm_qubit:
@@ -1929,7 +1934,7 @@ class Builder:
                 qubit_ids_array, ent_results_array, wait_all, params
             )
 
-        if params.post_routine is None and single_comm_qubit:
+        if params.post_routine is None and single_comm_qubit and has_mem_qubits:
             self._build_cmds_wait_move_epr_to_mem(
                 params=params, ent_results_array=ent_results_array, role=role
             )

--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -1903,8 +1903,8 @@ class Builder:
         )
 
         has_mem_qubits: bool = (
-                self._hardware_config is not None
-                and self._hardware_config.mem_qubit_count > 0
+            self._hardware_config is not None
+            and self._hardware_config.mem_qubit_count > 0
         )
 
         # If there is a post routine, handle pairs one by one.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Union
 
 from netqasm.lang.ir import BranchLabel, GenericInstr, ICmd, ProtoSubroutine
 from netqasm.logging.glob import get_netqasm_logger
-from netqasm.sdk.build_types import NVHardwareConfig
+from netqasm.sdk.build_types import GenericHardwareConfig, NVHardwareConfig
 from netqasm.sdk.connection import DebugConnection
 from netqasm.sdk.constraint import ValueAtMostConstraint
 from netqasm.sdk.epr_socket import EPRSocket
@@ -1087,6 +1087,68 @@ def test_create_keep_no_corrections():
         [
             GenericInstr.CREATE_EPR,
             GenericInstr.WAIT_ALL,
+            GenericInstr.RET_ARR,
+        ]
+    )
+
+
+def test_create_keep_single_comm_qubit_no_memory_qubits():
+    """
+    Check that if there is a single communication qubit, but no memory qubits,
+    the subroutine for creating an EPR pair does not contain a MOV instruction.
+    """
+    DebugConnection.node_ids = {
+        "Alice": 0,
+        "Bob": 1,
+    }
+
+    epr_socket = EPRSocket("Bob")
+
+    with DebugConnection("Alice", epr_sockets=[epr_socket]) as conn:
+        conn.builder._hardware_config = GenericHardwareConfig(1)
+
+        epr_socket.create_keep(number=1)
+
+        subroutine = conn.builder.subrt_pop_pending_subroutine()
+
+    inspector = ProtoSubroutineInspector(subroutine)
+    assert inspector.match_pattern(
+        [
+            GenericInstr.CREATE_EPR,
+            GenericInstr.RET_ARR,
+        ]
+    )
+
+
+def test_create_keep_single_comm_qubit_has_memory_qubits():
+    """
+    Check that if there is a single communication qubit and there are memory qubits,
+    the subroutine for creating an EPR pair does contain a MOV instruction.
+    """
+    DebugConnection.node_ids = {
+        "Alice": 0,
+        "Bob": 1,
+    }
+
+    epr_socket = EPRSocket("Bob")
+
+    with DebugConnection("Alice", epr_sockets=[epr_socket]) as conn:
+        conn.builder._hardware_config = GenericHardwareConfig(1)
+        conn.builder._hardware_config._mem_qubit_count = 1
+
+        epr_socket.create_keep(number=1)
+
+        subroutine = conn.builder.subrt_pop_pending_subroutine()
+
+    inspector = ProtoSubroutineInspector(subroutine)
+    assert inspector.match_pattern(
+        [
+            GenericInstr.CREATE_EPR,
+            PatternWildcard.ANY_ZERO_OR_MORE,
+            GenericInstr.WAIT_ALL,
+            PatternWildcard.ANY_ZERO_OR_MORE,
+            GenericInstr.MOV,
+            PatternWildcard.ANY_ZERO_OR_MORE,
             GenericInstr.RET_ARR,
         ]
     )


### PR DESCRIPTION
The current code will add a MOV instruction if only 1 communication qubit is available after EPR pair generation. But this is only possible if there is a memory qubit, as such an extra condition.
