### PR TITLE
Bugfix QubitNotActiveError when using qubits after epr create with min_fidelity_all_at_end specified

### DIFF
--- a/netqasm/sdk/builder.py
+++ b/netqasm/sdk/builder.py
@@ -2080,7 +2080,7 @@ class Builder:
                     # Otherwise: free the qubits.
                     if not params.sequential:
                         for q in qubits:
-                            q.free()
+                            q.free(deactivate=False)
 
                 loop.set_cleanup_code(cleanup)
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -753,7 +753,15 @@ def test_create_epr_min_fidelity_all():
     epr_socket = EPRSocket("Bob")
 
     with DebugConnection("Alice", epr_sockets=[epr_socket]) as conn:
-        epr_socket.create_keep(number=2, min_fidelity_all_at_end=80, max_tries=100)
+        qubits = epr_socket.create_keep(
+            number=2, min_fidelity_all_at_end=80, max_tries=100
+        )
+
+        # Check that qubits can be used for following instructions
+        q1, q2 = qubits
+        q1.cnot(q2)
+        q1.measure()
+        q2.measure()
 
         subroutine = conn._builder.subrt_pop_pending_subroutine()
         print(subroutine)
@@ -779,6 +787,14 @@ def test_create_epr_min_fidelity_all():
             PatternWildcard.ANY_ZERO_OR_MORE,
             GenericInstr.JMP,
             PatternWildcard.BRANCH_LABEL,
+            PatternWildcard.ANY_ZERO_OR_MORE,
+            GenericInstr.CNOT,
+            PatternWildcard.ANY_ZERO_OR_MORE,
+            GenericInstr.MEAS,
+            PatternWildcard.ANY_ZERO_OR_MORE,
+            GenericInstr.MEAS,
+            PatternWildcard.ANY_ZERO_OR_MORE,
+            GenericInstr.RET_ARR,
         ]
     )
 


### PR DESCRIPTION
Fix bug when using qubits after creating multiple qubits with min_fidelity_all_at_end specified. qubits are incorrectly deactivated during compilation in the SDK. Using the EPR qubits in this situation will trigger a QubitNotActiveError when adding a measure instruction to the subroutine for that qubit.

* Qubits are not deactivated in the cleanup code inside sdk_create_epr_keep in the builder when min_fidelity_all_at_end is used
* Expanded test_create_epr_min_fidelity_all test to check if the qubits created can be used for gates and measurements and don't trigger an error that they are not active